### PR TITLE
Fix a pop and click in chorus

### DIFF
--- a/Source/ChorusEffect.cpp
+++ b/Source/ChorusEffect.cpp
@@ -16,7 +16,7 @@ ChorusEffect::~ChorusEffect() { }
 
 double ChorusEffect::processSignal(float sample, double lfoRate){
     double delayedSample = 0;
-    delayedSample = delay.dl(sample, 350*lfo.sinebuf4(lfoRate), 0);
+    delayedSample = delay.dl(sample, 1 + 175*( 1 + lfo.sinebuf4(lfoRate)), 0);
     return sample + delayedSample;
 }
 


### PR DESCRIPTION
Hi

This is a fix independent of the move to juce6. 

Chorus did a delay by 350 8 sin(phase) which is in the range -1,1.

The delay did a fabs which meant correctly that it was always looking in the past, but that
the delay value changed very rapidly near zero, leading to occasional
pops and clicks. 

Repalce 350 * sin with 175 * ( 1 + sin ) + 1 in the delay
time to stop this, and the chorus pops and clicks vanish.

Thanks!